### PR TITLE
Reset previous commit and changes only to text ("primary" --> "default")

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "ll-property-image",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "authors": [
     "Aaron Hickman <ahickman@leisurelink.com>",
     "Chris Tanseer <chris@christanseer.com>"

--- a/ll-property-image.html
+++ b/ll-property-image.html
@@ -257,8 +257,8 @@ Example:
         <ll-token-field id="tags" tags='{{tags}}' placeholder="Click 'tab' to enter a tag..."></ll-token-field>
 
         <div class="image-actions no-select">
-          <button hidden$="{{isDefault}}" id="default-image" class="btn btn-link pull-left" on-tap="makeDefaultImage">SET AS DEFAULT</button>
-          <div hidden$="{{!isDefault}}" id="default-image-label" class="pull-left">DEFAULT IMAGE</div>
+          <button hidden$="{{isDefault}}" id="default-image" class="btn btn-link pull-left" on-tap="makeDefaultImage">SET AS PRIMARY</button>
+          <div hidden$="{{!isDefault}}" id="default-image-label" class="pull-left">PRIMARY IMAGE</div>
           <button id="delete-image" class="btn btn-link pull-right" on-tap='deleteImage'>DELETE</button>
         </div>
 

--- a/ll-property-image.html
+++ b/ll-property-image.html
@@ -354,7 +354,7 @@ Example:
         observer: '_metaDataChanged'
       },
       /**
-       * Used to track if this is the default image in the gallery.
+       * Used to track if this is the primary image in the gallery.
        */
       isPrimary: {
         type: Boolean,

--- a/ll-property-image.html
+++ b/ll-property-image.html
@@ -8,7 +8,7 @@
 <!--
 Example:
 
-    <ll-property-image id="1234" img-name="dc13416.jpg" img-title="My Kitchen" src="http://lorempixel.com/600/400" img-sizing="cover" tags="['1','2']" is-default></ll-property-image>
+    <ll-property-image id="1234" img-name="dc13416.jpg" img-title="My Kitchen" src="http://lorempixel.com/600/400" img-sizing="cover" tags="['1','2']" is-primary></ll-property-image>
 
 @demo
 -->
@@ -257,8 +257,8 @@ Example:
         <ll-token-field id="tags" tags='{{tags}}' placeholder="Click 'tab' to enter a tag..."></ll-token-field>
 
         <div class="image-actions no-select">
-          <button hidden$="{{isDefault}}" id="default-image" class="btn btn-link pull-left" on-tap="makeDefaultImage">SET AS DEFAULT</button>
-          <div hidden$="{{!isDefault}}" id="default-image-label" class="pull-left">DEFAULT IMAGE</div>
+          <button hidden$="{{isPrimary}}" id="primary-image" class="btn btn-link pull-left" on-tap="makePrimaryImage">SET AS PRIMARY</button>
+          <div hidden$="{{!isPrimary}}" id="default-image-label" class="pull-left">PRIMARY IMAGE</div>
           <button id="delete-image" class="btn btn-link pull-right" on-tap='deleteImage'>DELETE</button>
         </div>
 
@@ -356,7 +356,7 @@ Example:
       /**
        * Used to track if this is the default image in the gallery.
        */
-      isDefault: {
+      isPrimary: {
         type: Boolean,
         value: false
       },
@@ -427,9 +427,9 @@ Example:
       });
     },
     /**
-     * Toggles the Default Image value, and raises an event.
+     * Toggles the Primary Image value, and raises an event.
      */
-    makeDefaultImage: function() {
+    makePrimaryImage: function() {
       if(this.readOnly) {
         return;
       }
@@ -437,13 +437,13 @@ Example:
       var image = {
         imgId: this.imgId,
         name: this.name,
-        isDefault: true,
+        isPrimary: true,
         title: this.title,
         description: this.description,
         sortOrder: this.sortOrder,
         tags: this.tags
       };
-      this.fire('ll-property-image-default', image);
+      this.fire('ll-property-image-primary', image);
     },
     /**
      * Method to change the image src.
@@ -486,7 +486,7 @@ Example:
     },
     /**
      * Method to grab the Metadata that would be needed to save the changes.
-     * @returns {{title: (properties.title|{type, observer}|*|properties.name|{type}|string), description: (properties.description|{type, value, notify, observer}|*|string|string), isDefault: *}}
+     * @returns {{title: (properties.title|{type, observer}|*|properties.name|{type}|string), description: (properties.description|{type, value, notify, observer}|*|string|string), isPrimary: *}}
      */
     getChanges: function() {
       return {
@@ -497,7 +497,7 @@ Example:
         tags: this.tags,
         sortOrder: this.sortOrder,
         fileName: this.name,
-        isDefault: this.isDefault
+        isPrimary: this.isPrimary
       };
     },
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ll-property-image",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A web component to display Leisure Link Images.",
   "main": "index.html",
   "directories": {

--- a/test/events.html
+++ b/test/events.html
@@ -18,7 +18,7 @@
 
   <test-fixture id="fixture">
     <template>
-      <ll-property-image class="test2" img-id="1234567" name="dc134145.jpg" description="This is a description" src="http://lorempixel.com/600/400" sizing="contain" title="This is a title" is-default></ll-property-image>
+      <ll-property-image class="test2" img-id="1234567" name="dc134145.jpg" description="This is a description" src="http://lorempixel.com/600/400" sizing="contain" title="This is a title" is-primary></ll-property-image>
     </template>
   </test-fixture>
 

--- a/test/optional-params.html
+++ b/test/optional-params.html
@@ -18,7 +18,7 @@
 
   <test-fixture id="fixture">
     <template>
-      <ll-property-image sort-order="2" class="test2" img-id="12345" name="dc134145.jpg" description="This is a description" src="http://lorempixel.com/600/400" sizing="contain" title="This is a title" is-default></ll-property-image>
+      <ll-property-image sort-order="2" class="test2" img-id="12345" name="dc134145.jpg" description="This is a description" src="http://lorempixel.com/600/400" sizing="contain" title="This is a title" is-primary></ll-property-image>
     </template>
   </test-fixture>
 

--- a/test/public-functions.html
+++ b/test/public-functions.html
@@ -18,7 +18,7 @@
 
   <test-fixture id="fixture">
     <template>
-      <ll-property-image class="test2" img-id="123456" name="dc134145.jpg" description="This is a description" src="http://lorempixel.com/600/400" sizing="contain" title="This is a title" is-default tags='["Rufus", "Garfield", "Beavis"]' sort-order="2 "></ll-property-image>
+      <ll-property-image class="test2" img-id="123456" name="dc134145.jpg" description="This is a description" src="http://lorempixel.com/600/400" sizing="contain" title="This is a title" is-primary tags='["Rufus", "Garfield", "Beavis"]' sort-order="2 "></ll-property-image>
     </template>
   </test-fixture>
 

--- a/test/read-only.html
+++ b/test/read-only.html
@@ -18,7 +18,7 @@
 
   <test-fixture id="fixture">
     <template>
-      <ll-property-image class="test2" img-id="123456" name="dc134145.jpg" description="This is a description" src="http://lorempixel.com/600/400" sizing="contain" title="This is a title" is-default tags='["Rufus", "Garfield", "Beavis"]' sort-order="2 " read-only></ll-property-image>
+      <ll-property-image class="test2" img-id="123456" name="dc134145.jpg" description="This is a description" src="http://lorempixel.com/600/400" sizing="contain" title="This is a title" is-primary tags='["Rufus", "Garfield", "Beavis"]' sort-order="2 " read-only></ll-property-image>
     </template>
   </test-fixture>
 

--- a/test/scripts/basic-test.js
+++ b/test/scripts/basic-test.js
@@ -19,8 +19,8 @@ describe('<ll-property-image> - Required Inputs', function() {
     expect(element.sizing).to.be.eql('cover');
   });
 
-  it('should default the isDefault property to false if it is not provided', function() {
-    expect(element.isDefault).to.be.eql(false);
+  it('should default the isPrimary property to false if it is not provided', function() {
+    expect(element.isPrimary).to.be.eql(false);
   });
 
   it('should default the sortOrder if it is not provided', function() {

--- a/test/scripts/events.js
+++ b/test/scripts/events.js
@@ -17,8 +17,8 @@ describe('<ll-property-image> - Optional Inputs', function() {
       element.deleteImage();
     });
 
-    it('should raise an event for Make Default Image', function() {
-      element.addEventListener('ll-property-image-default', function(event) {
+    it('should raise an event for Make Primary Image', function() {
+      element.addEventListener('ll-property-image-primary', function(event) {
         expect(event.detail).to.be.eql({
           dirty: false,
           imgId: "1234567",
@@ -27,11 +27,11 @@ describe('<ll-property-image> - Optional Inputs', function() {
           tags: [],
           sortOrder: 1,
           fileName: "dc134145.jpg",
-          isDefault: false
+          isPrimary: false
         });
       });
 
-      element.makeDefaultImage();
+      element.makePrimaryImage();
     });
 
     it('should raise an event for cleaning up styles after a drag drop', function() {

--- a/test/scripts/optional-params.js
+++ b/test/scripts/optional-params.js
@@ -19,8 +19,8 @@ describe('<ll-property-image> - Optional Inputs', function() {
     expect(element.title).to.be.eql('This is a title');
   });
 
-  it('should optionally take a isDefault property', function() {
-    expect(element.isDefault).to.be.eql(true);
+  it('should optionally take a isPrimary property', function() {
+    expect(element.isPrimary).to.be.eql(true);
   });
 
   it('should optionally take a sortOrder property', function() {

--- a/test/scripts/public-functions.js
+++ b/test/scripts/public-functions.js
@@ -73,7 +73,7 @@ describe('<ll-property-image> - Optional Inputs', function() {
       expect(changes).to.have.deep.property('imgId');
       expect(changes).to.have.deep.property('sortOrder');
       expect(changes).to.have.deep.property('fileName');
-      expect(changes).to.have.deep.property('isDefault');
+      expect(changes).to.have.deep.property('isPrimary');
       expect(changes).to.be.eql({
         dirty: false,
         imgId: '123456',
@@ -82,7 +82,7 @@ describe('<ll-property-image> - Optional Inputs', function() {
         tags: ['Rufus', 'Garfield', 'Beavis'],
         sortOrder: 2,
         fileName: "dc134145.jpg",
-        isDefault: true
+        isPrimary: true
       });
     });
 


### PR DESCRIPTION
this branch does a git reset hard back to before i started to change default to primary ... 

then i sync with master but change everything but the text back to before ... probably easiest to look at first commit and verify that the only thing that's changed is the button text and then verify that the second commit keeps only the changes from that first commit (and discards the rest of the changes I made that are currently in the master branch)

you can also verify by pulling this branch down and doing a find for 'primary' in `ll-property-images.html`. (The find shouldn't find anything.)
